### PR TITLE
test: add comprehensive test suite with 99.31% coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ temp/
 *.log
 .env
 test-output/
+coverage/
 claude-export/
 *.png
 0532b8293bb107be5c0c20f3e2980f09107f44de9a58414157f5bed3f7ef0d19*/

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Node.js Version](https://img.shields.io/badge/node-%3E%3D18.0.0-brightgreen)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.9-blue)](https://www.typescriptlang.org/)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
+![Coverage](https://img.shields.io/badge/coverage-99.31%25-brightgreen)
 
 [Features](#-features) • [Quick Start](#-quick-start) • [Usage](#-usage) • [Documentation](#-documentation) • [Contributing](#-contributing)
 
@@ -315,8 +316,11 @@ npm run dev convert export.zip
 # Build TypeScript
 npm run build
 
-# Run tests (coming soon)
+# Run tests
 npm test
+
+# Run tests with coverage
+npm run test:coverage
 ```
 
 ### Project Structure
@@ -498,7 +502,7 @@ npm start -- convert export.zip --skip-preferences
 - [ ] Conversation search and filtering
 - [ ] Web UI for easier use
 - [ ] Better image handling (Base64 embedding)
-- [ ] Automated tests
+- [x] Automated tests
 - [ ] Multi-language support
 
 ### Future Possibilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,18 +7,83 @@
     "": {
       "name": "context-swapper",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MIT",
       "dependencies": {
         "adm-zip": "^0.5.16",
         "chalk": "^5.6.2",
         "commander": "^13.1.0",
         "ollama": "^0.6.3"
       },
+      "bin": {
+        "context-swapper": "dist/index.js"
+      },
       "devDependencies": {
         "@types/adm-zip": "^0.5.7",
         "@types/node": "^25.2.1",
+        "@vitest/coverage-v8": "^4.0.18",
         "tsx": "^4.21.0",
-        "typescript": "^5.9.3"
+        "typescript": "^5.9.3",
+        "vitest": "^4.0.18"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
+      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -463,6 +528,391 @@
         "node": ">=18"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/adm-zip": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@types/adm-zip/-/adm-zip-0.5.7.tgz",
@@ -472,6 +922,31 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "25.2.1",
@@ -483,6 +958,148 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.0.18.tgz",
+      "integrity": "sha512-7i+N2i0+ME+2JFZhfuz7Tg/FqKtilHjGyGvoHYQ6iLV0zahbsJ9sljC9OcFcPDbhYKCet+sG8SsVqlyGvPflZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.0.18",
+        "ast-v8-to-istanbul": "^0.3.10",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.1",
+        "obug": "^2.1.1",
+        "std-env": "^3.10.0",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.0.18",
+        "vitest": "4.0.18"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/adm-zip": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
@@ -490,6 +1107,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.0"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.11.tgz",
+      "integrity": "sha512-Qya9fkoofMjCBNVdWINMjB5KZvkYfaO9/anwkWnjxibpWUxo5iHl2sOdP7/uAqaRuUYuoo8rDwnbaaKVFxoUvw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/chalk": {
@@ -512,6 +1161,13 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -555,6 +1211,44 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -583,6 +1277,137 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.2.tgz",
+      "integrity": "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/ollama": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/ollama/-/ollama-0.6.3.tgz",
@@ -590,6 +1415,62 @@
       "license": "MIT",
       "dependencies": {
         "whatwg-fetch": "^3.6.20"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -600,6 +1481,152 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tsx": {
@@ -643,11 +1670,181 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,9 +11,17 @@
     "build": "tsc",
     "start": "tsx src/index.ts",
     "dev": "tsx watch src/index.ts",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage"
   },
-  "keywords": ["chatgpt", "claude", "conversation", "export", "converter", "ai"],
+  "keywords": [
+    "chatgpt",
+    "claude",
+    "conversation",
+    "export",
+    "converter",
+    "ai"
+  ],
   "author": "",
   "license": "MIT",
   "dependencies": {
@@ -25,7 +33,9 @@
   "devDependencies": {
     "@types/adm-zip": "^0.5.7",
     "@types/node": "^25.2.1",
+    "@vitest/coverage-v8": "^4.0.18",
     "tsx": "^4.21.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/tests/analyzers/ollama-preferences.test.ts
+++ b/tests/analyzers/ollama-preferences.test.ts
@@ -1,0 +1,361 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { OllamaPreferenceAnalyzer } from '../../src/analyzers/ollama-preferences';
+import type { NormalizedConversation } from '../../src/parsers/types';
+
+// Mock the ollama module
+vi.mock('ollama', () => {
+  const OllamaMock = class {
+    list: ReturnType<typeof vi.fn>;
+    generate: ReturnType<typeof vi.fn>;
+    constructor() {
+      this.list = vi.fn();
+      this.generate = vi.fn();
+    }
+  };
+  return { Ollama: OllamaMock };
+});
+
+describe('OllamaPreferenceAnalyzer', () => {
+  let analyzer: OllamaPreferenceAnalyzer;
+
+  beforeEach(() => {
+    analyzer = new OllamaPreferenceAnalyzer('test-model', 'http://localhost:11434');
+  });
+
+  describe('constructor', () => {
+    it('creates instance with default parameters', () => {
+      const defaultAnalyzer = new OllamaPreferenceAnalyzer();
+      expect(defaultAnalyzer).toBeInstanceOf(OllamaPreferenceAnalyzer);
+    });
+
+    it('creates instance with custom parameters', () => {
+      const customAnalyzer = new OllamaPreferenceAnalyzer('custom-model', 'http://custom:1234');
+      expect(customAnalyzer).toBeInstanceOf(OllamaPreferenceAnalyzer);
+    });
+  });
+
+  describe('analyzePreferences', () => {
+    it('throws error when Ollama is not available', async () => {
+      const conversations = createSampleConversations(2);
+
+      // Access private ollama instance and mock list to throw
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      await expect(analyzer.analyzePreferences(conversations)).rejects.toThrow(
+        'Ollama analysis failed'
+      );
+    });
+
+    it('throws error when model is not found', async () => {
+      const conversations = createSampleConversations(2);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({ models: [{ name: 'other-model' }] });
+
+      await expect(analyzer.analyzePreferences(conversations)).rejects.toThrow(
+        "Model 'test-model' not found"
+      );
+    });
+
+    it('returns generated preferences when successful', async () => {
+      const conversations = createSampleConversations(2);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockResolvedValue({
+        response: 'I prefer clear explanations.',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const result = await analyzer.analyzePreferences(conversations);
+      consoleSpy.mockRestore();
+
+      expect(result).toBe('I prefer clear explanations.');
+    });
+
+    it('returns fallback text when response is empty', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockResolvedValue({ response: '' });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const result = await analyzer.analyzePreferences(conversations);
+      consoleSpy.mockRestore();
+
+      expect(result).toBe('No preferences generated.');
+    });
+
+    it('wraps non-Error exceptions', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockRejectedValue('string error');
+
+      await expect(analyzer.analyzePreferences(conversations)).rejects.toThrow(
+        'Failed to connect to Ollama'
+      );
+    });
+
+    it('re-throws non-Error from generate call', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockRejectedValue(42);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await expect(analyzer.analyzePreferences(conversations)).rejects.toBe(42);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('analyzeMemory', () => {
+    it('throws error when Ollama is not available', async () => {
+      const conversations = createSampleConversations(2);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockRejectedValue(new Error('connect ECONNREFUSED'));
+
+      await expect(analyzer.analyzeMemory(conversations)).rejects.toThrow(
+        'Ollama memory generation failed'
+      );
+    });
+
+    it('returns generated memory when successful', async () => {
+      const conversations = createSampleConversations(2);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockResolvedValue({
+        response: 'Work context: User is a developer.',
+      });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const result = await analyzer.analyzeMemory(conversations);
+      consoleSpy.mockRestore();
+
+      expect(result).toBe('Work context: User is a developer.');
+    });
+
+    it('returns fallback text when response is empty', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockResolvedValue({ response: '' });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const result = await analyzer.analyzeMemory(conversations);
+      consoleSpy.mockRestore();
+
+      expect(result).toBe('No memory generated.');
+    });
+
+    it('wraps non-Error exceptions', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockRejectedValue('string error');
+
+      await expect(analyzer.analyzeMemory(conversations)).rejects.toThrow(
+        'Failed to connect to Ollama'
+      );
+    });
+
+    it('re-throws non-Error from generate call', async () => {
+      const conversations = createSampleConversations(1);
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockRejectedValue(99);
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await expect(analyzer.analyzeMemory(conversations)).rejects.toBe(99);
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe('generateBasicPreferences', () => {
+    it('generates basic stats-based preferences', () => {
+      const conversations = createSampleConversations(3);
+      const result = analyzer.generateBasicPreferences(conversations);
+
+      expect(result).toContain('3 conversations');
+      expect(result).toContain('total messages');
+      expect(result).toContain('clear, concise explanations');
+      expect(result).toContain('Note:');
+    });
+
+    it('includes topic keywords from conversation titles', () => {
+      const conversations = [
+        createConversation('1', 'Docker Container Setup', 2),
+        createConversation('2', 'Docker Deployment Guide', 2),
+      ];
+
+      const result = analyzer.generateBasicPreferences(conversations);
+      expect(result).toContain('docker');
+    });
+
+    it('handles empty conversations list', () => {
+      const result = analyzer.generateBasicPreferences([]);
+      expect(result).toContain('0 conversations');
+    });
+  });
+
+  describe('generateBasicMemory', () => {
+    it('generates basic memory document', () => {
+      const conversations = createSampleConversations(3);
+      const result = analyzer.generateBasicMemory(conversations);
+
+      expect(result).toContain('Work context:');
+      expect(result).toContain('Personal context:');
+      expect(result).toContain('Top of mind:');
+      expect(result).toContain('Note:');
+    });
+
+    it('includes recent conversation titles', () => {
+      const conversations = [
+        createConversation('1', 'Recent Topic Alpha', 2),
+        createConversation('2', 'Recent Topic Beta', 2),
+      ];
+
+      const result = analyzer.generateBasicMemory(conversations);
+      expect(result).toContain('Recent Topic');
+    });
+
+    it('handles empty conversations list', () => {
+      const result = analyzer.generateBasicMemory([]);
+      expect(result).toContain('Work context:');
+      expect(result).toContain('No recent conversation data available.');
+    });
+
+    it('includes topic keywords when available', () => {
+      const conversations = [
+        createConversation('1', 'Python Programming Tutorial', 2),
+        createConversation('2', 'Python Testing Guide', 2),
+      ];
+
+      const result = analyzer.generateBasicMemory(conversations);
+      expect(result).toContain('python');
+    });
+
+    it('handles conversations with no extractable topics', () => {
+      const conversations = [
+        createConversation('1', 'Hi', 1),
+        createConversation('2', 'Ok', 1),
+      ];
+
+      const result = analyzer.generateBasicMemory(conversations);
+      expect(result).toContain('User background and interests require AI analysis');
+    });
+  });
+
+  describe('prepareConversationText (via analyzePreferences)', () => {
+    it('sorts conversations chronologically', async () => {
+      const conversations = [
+        createConversation('2', 'Second Chat', 1, new Date('2024-02-01')),
+        createConversation('1', 'First Chat', 1, new Date('2024-01-01')),
+      ];
+
+      // Access the private method indirectly via the prompt that would be built
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockImplementation(async (params: any) => {
+        // Verify the conversation text has First before Second
+        const firstIdx = params.prompt.indexOf('First Chat');
+        const secondIdx = params.prompt.indexOf('Second Chat');
+        expect(firstIdx).toBeLessThan(secondIdx);
+        return { response: 'result' };
+      });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      await analyzer.analyzePreferences(conversations);
+      consoleSpy.mockRestore();
+    });
+
+    it('truncates when exceeding max tokens', async () => {
+      // maxTokens is 100000, maxChars = 100000 * 4 = 400000
+      // Each conversation needs enough content to eventually exceed this
+      const longConversations = [];
+      for (let i = 0; i < 200; i++) {
+        const conv = createConversation(
+          `${i}`,
+          `Conversation ${i} about topic`,
+          1,
+          new Date(`2024-01-${String(i % 28 + 1).padStart(2, '0')}`)
+        );
+        conv.messages[0].content = 'x'.repeat(5000);
+        longConversations.push(conv);
+      }
+
+      // Reduce maxTokens to make truncation happen faster
+      (analyzer as any).maxTokens = 100; // 100 * 4 = 400 chars max
+
+      const ollamaInstance = (analyzer as any).ollama;
+      ollamaInstance.list.mockResolvedValue({
+        models: [{ name: 'test-model' }],
+      });
+      ollamaInstance.generate.mockResolvedValue({ response: 'result' });
+
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await analyzer.analyzePreferences(longConversations);
+
+      // The truncation warning should have been logged
+      expect(warnSpy).toHaveBeenCalled();
+
+      consoleSpy.mockRestore();
+      warnSpy.mockRestore();
+    });
+  });
+});
+
+function createSampleConversations(count: number): NormalizedConversation[] {
+  return Array.from({ length: count }, (_, i) =>
+    createConversation(
+      `conv${i}`,
+      `Conversation ${i} about programming`,
+      2 + i,
+      new Date(`2024-01-${String(i + 1).padStart(2, '0')}`)
+    )
+  );
+}
+
+function createConversation(
+  id: string,
+  title: string,
+  messageCount: number,
+  created: Date = new Date('2024-01-01'),
+): NormalizedConversation {
+  const messages = Array.from({ length: messageCount }, (_, i) => ({
+    role: (i % 2 === 0 ? 'user' : 'assistant') as 'user' | 'assistant',
+    content: `Message ${i} content`,
+    timestamp: new Date(created.getTime() + i * 60000),
+  }));
+
+  return {
+    id,
+    title,
+    created,
+    updated: new Date(created.getTime() + messageCount * 60000),
+    messages,
+  };
+}

--- a/tests/extractor.test.ts
+++ b/tests/extractor.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import AdmZip from 'adm-zip';
+import { ZipExtractor } from '../src/extractor';
+
+describe('ZipExtractor', () => {
+  let extractor: ZipExtractor;
+  let testDir: string;
+
+  beforeEach(() => {
+    extractor = new ZipExtractor();
+    testDir = join(tmpdir(), `extractor-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('extractZip', () => {
+    it('extracts zip with conversations.json', async () => {
+      const zipPath = createTestZip(testDir, {
+        'conversations.json': JSON.stringify([{ conversation_id: 'test' }]),
+      });
+
+      const result = await extractor.extractZip(zipPath);
+
+      expect(result.conversationsPath).toContain('conversations.json');
+      expect(existsSync(result.conversationsPath)).toBe(true);
+      expect(result.tempDir).toBeTruthy();
+
+      // Cleanup
+      extractor.cleanup(result.tempDir);
+    });
+
+    it('includes userPath when user.json exists', async () => {
+      const zipPath = createTestZip(testDir, {
+        'conversations.json': '[]',
+        'user.json': JSON.stringify({ id: 'user1', email: 'test@example.com' }),
+      });
+
+      const result = await extractor.extractZip(zipPath);
+
+      expect(result.userPath).toBeDefined();
+      expect(existsSync(result.userPath!)).toBe(true);
+
+      extractor.cleanup(result.tempDir);
+    });
+
+    it('sets userPath to undefined when user.json does not exist', async () => {
+      const zipPath = createTestZip(testDir, {
+        'conversations.json': '[]',
+      });
+
+      const result = await extractor.extractZip(zipPath);
+      expect(result.userPath).toBeUndefined();
+
+      extractor.cleanup(result.tempDir);
+    });
+
+    it('includes imagesDir when images directory exists', async () => {
+      const zipPath = createTestZip(testDir, {
+        'conversations.json': '[]',
+        'images/test.png': 'fake-image-data',
+      });
+
+      const result = await extractor.extractZip(zipPath);
+
+      expect(result.imagesDir).toBeDefined();
+      expect(existsSync(result.imagesDir!)).toBe(true);
+
+      extractor.cleanup(result.tempDir);
+    });
+
+    it('sets imagesDir to undefined when images directory does not exist', async () => {
+      const zipPath = createTestZip(testDir, {
+        'conversations.json': '[]',
+      });
+
+      const result = await extractor.extractZip(zipPath);
+      expect(result.imagesDir).toBeUndefined();
+
+      extractor.cleanup(result.tempDir);
+    });
+
+    it('throws error when zip file does not exist', async () => {
+      await expect(extractor.extractZip('/nonexistent/file.zip')).rejects.toThrow(
+        'Zip file not found'
+      );
+    });
+
+    it('throws error when conversations.json is missing from zip', async () => {
+      const zipPath = createTestZip(testDir, {
+        'readme.txt': 'No conversations here',
+      });
+
+      await expect(extractor.extractZip(zipPath)).rejects.toThrow(
+        'conversations.json not found in zip archive'
+      );
+    });
+  });
+
+  describe('cleanup', () => {
+    it('removes temporary directory', () => {
+      const tempDir = join(testDir, 'temp-cleanup');
+      mkdirSync(tempDir, { recursive: true });
+      writeFileSync(join(tempDir, 'test.txt'), 'data');
+
+      expect(existsSync(tempDir)).toBe(true);
+      extractor.cleanup(tempDir);
+      expect(existsSync(tempDir)).toBe(false);
+    });
+
+    it('does nothing when directory does not exist', () => {
+      expect(() => extractor.cleanup('/nonexistent/dir')).not.toThrow();
+    });
+
+    it('handles errors gracefully without throwing', () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      // Calling cleanup on nonexistent dir should not throw
+      expect(() => extractor.cleanup('/nonexistent/dir')).not.toThrow();
+      consoleSpy.mockRestore();
+    });
+  });
+});
+
+function createTestZip(dir: string, files: Record<string, string>): string {
+  const zip = new AdmZip();
+
+  for (const [path, content] of Object.entries(files)) {
+    zip.addFile(path, Buffer.from(content));
+  }
+
+  const zipPath = join(dir, 'test-export.zip');
+  zip.writeZip(zipPath);
+
+  return zipPath;
+}

--- a/tests/formatters/markdown.test.ts
+++ b/tests/formatters/markdown.test.ts
@@ -1,0 +1,219 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { MarkdownFormatter } from '../../src/formatters/markdown';
+import type { NormalizedConversation, NormalizedMessage } from '../../src/parsers/types';
+
+describe('MarkdownFormatter', () => {
+  let formatter: MarkdownFormatter;
+
+  beforeEach(() => {
+    formatter = new MarkdownFormatter();
+  });
+
+  describe('formatConversation', () => {
+    it('formats a conversation with header and metadata', () => {
+      const conversation = createConversation('Test Chat', [
+        createMessage('user', 'Hello!'),
+        createMessage('assistant', 'Hi there!'),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).toContain('# Test Chat');
+      expect(result).toContain('**Created:**');
+      expect(result).toContain('**Last Updated:**');
+      expect(result).toContain('**Messages:** 2');
+      expect(result).toContain('## User');
+      expect(result).toContain('Hello!');
+      expect(result).toContain('## Assistant');
+      expect(result).toContain('Hi there!');
+    });
+
+    it('includes footer', () => {
+      const conversation = createConversation('Test', [
+        createMessage('user', 'Hello'),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+      expect(result).toContain('*Exported from ChatGPT via context-swapper*');
+    });
+
+    it('includes separator between metadata and messages', () => {
+      const conversation = createConversation('Test', [
+        createMessage('user', 'Hello'),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+      expect(result).toContain('---');
+    });
+
+    it('escapes markdown special characters in title', () => {
+      const conversation = createConversation('Test #1 with *bold* and _underline_', [
+        createMessage('user', 'Hello'),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+      expect(result).toContain('\\#');
+      expect(result).toContain('\\*');
+      expect(result).toContain('\\_');
+    });
+
+    it('formats messages with images', () => {
+      const msg = createMessage('user', 'Check this');
+      msg.images = ['file://image1.png', 'file://image2.jpg'];
+
+      const conversation = createConversation('Test', [msg]);
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).toContain('[Image: file://image1.png]');
+      expect(result).toContain('[Image: file://image2.jpg]');
+    });
+
+    it('formats messages with attachments', () => {
+      const msg = createMessage('user', 'See attached');
+      msg.metadata = { attachments: ['doc.pdf', 'data.csv'] };
+
+      const conversation = createConversation('Test', [msg]);
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).toContain('[Attachment: doc.pdf]');
+      expect(result).toContain('[Attachment: data.csv]');
+    });
+
+    it('includes model info for assistant messages', () => {
+      const msg = createMessage('assistant', 'Response');
+      msg.metadata = { model: 'gpt-4' };
+
+      const conversation = createConversation('Test', [msg]);
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).toContain('*Model: gpt-4*');
+    });
+
+    it('does not include model info for user messages', () => {
+      const msg = createMessage('user', 'Question');
+      msg.metadata = { model: 'gpt-4' };
+
+      const conversation = createConversation('Test', [msg]);
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).not.toContain('*Model: gpt-4*');
+    });
+
+    it('handles system role label', () => {
+      const conversation = createConversation('Test', [
+        createMessage('system', 'You are helpful'),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+      expect(result).toContain('## System');
+    });
+
+    it('handles unknown role label', () => {
+      const msg = createMessage('user', 'Test');
+      (msg as any).role = 'unknown';
+
+      const conversation = createConversation('Test', [msg]);
+      const result = formatter.formatConversation(conversation);
+
+      expect(result).toContain('## Unknown');
+    });
+
+    it('handles empty message content', () => {
+      const conversation = createConversation('Test', [
+        createMessage('user', ''),
+      ]);
+
+      const result = formatter.formatConversation(conversation);
+      expect(result).toContain('## User');
+    });
+  });
+
+  describe('formatIndex', () => {
+    it('generates conversation index', () => {
+      const conversations = [
+        createConversation('First Chat', [createMessage('user', 'Hi')]),
+        createConversation('Second Chat', [createMessage('user', 'Hello')]),
+      ];
+
+      const result = formatter.formatIndex(conversations);
+
+      expect(result).toContain('# Conversation Index');
+      expect(result).toContain('Total conversations: 2');
+      expect(result).toContain('### 1. First Chat');
+      expect(result).toContain('### 2. Second Chat');
+      expect(result).toContain('**File:**');
+      expect(result).toContain('**Created:**');
+      expect(result).toContain('**Messages:**');
+    });
+
+    it('handles empty conversations list', () => {
+      const result = formatter.formatIndex([]);
+
+      expect(result).toContain('# Conversation Index');
+      expect(result).toContain('Total conversations: 0');
+    });
+
+    it('escapes markdown in conversation titles', () => {
+      const conversations = [
+        createConversation('Test #1 *important*', [createMessage('user', 'Hi')]),
+      ];
+
+      const result = formatter.formatIndex(conversations);
+      expect(result).toContain('\\#');
+      expect(result).toContain('\\*');
+    });
+  });
+
+  describe('generateFilename', () => {
+    it('generates padded index with sanitized title', () => {
+      expect(formatter.generateFilename(1, 'Hello World')).toBe('001-hello-world.md');
+    });
+
+    it('pads index with zeros', () => {
+      expect(formatter.generateFilename(42, 'Test')).toBe('042-test.md');
+    });
+
+    it('removes special characters from title', () => {
+      expect(formatter.generateFilename(1, 'Hello! @World #2024')).toBe('001-hello-world-2024.md');
+    });
+
+    it('truncates long titles to 50 chars', () => {
+      const longTitle = 'This is a very long conversation title that exceeds fifty characters easily';
+      const result = formatter.generateFilename(1, longTitle);
+      const nameWithoutIndex = result.replace('001-', '').replace('.md', '');
+      expect(nameWithoutIndex.length).toBeLessThanOrEqual(50);
+    });
+
+    it('handles empty title', () => {
+      expect(formatter.generateFilename(1, '')).toBe('001-.md');
+    });
+
+    it('removes leading and trailing hyphens from sanitized title', () => {
+      expect(formatter.generateFilename(1, '---Test---')).toBe('001-test.md');
+    });
+  });
+});
+
+function createConversation(
+  title: string,
+  messages: NormalizedMessage[]
+): NormalizedConversation {
+  return {
+    id: 'conv-test',
+    title,
+    created: new Date('2024-01-15'),
+    updated: new Date('2024-01-16'),
+    messages,
+  };
+}
+
+function createMessage(
+  role: 'user' | 'assistant' | 'system',
+  content: string
+): NormalizedMessage {
+  return {
+    role,
+    content,
+    timestamp: new Date('2024-01-15T10:00:00Z'),
+  };
+}

--- a/tests/parsers/chatgpt.test.ts
+++ b/tests/parsers/chatgpt.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ChatGPTParser } from '../../src/parsers/chatgpt';
+import type { Message, MessageNode } from '../../src/parsers/types';
+
+describe('ChatGPTParser', () => {
+  let parser: ChatGPTParser;
+  let testDir: string;
+
+  beforeEach(() => {
+    parser = new ChatGPTParser();
+    testDir = join(tmpdir(), `chatgpt-parser-test-${Date.now()}`);
+    mkdirSync(testDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  describe('parseConversations', () => {
+    it('parses array format conversations.json', () => {
+      const data = [
+        {
+          conversation_id: 'conv1',
+          title: 'Test Conversation',
+          create_time: 1700000000,
+          update_time: 1700001000,
+          mapping: {},
+          current_node: 'node1',
+          moderation_results: [],
+          plugin_ids: null,
+          conversation_template_id: null,
+          gizmo_id: null,
+          is_archived: false,
+          safe_urls: [],
+        },
+      ];
+      const filePath = join(testDir, 'conversations.json');
+      writeFileSync(filePath, JSON.stringify(data));
+
+      const result = parser.parseConversations(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0].conversation_id).toBe('conv1');
+      expect(result[0].title).toBe('Test Conversation');
+    });
+
+    it('parses object format with conversations property', () => {
+      const data = {
+        conversations: [
+          {
+            conversation_id: 'conv2',
+            title: 'Object Format',
+            create_time: 1700000000,
+            update_time: 1700001000,
+            mapping: {},
+            current_node: 'node1',
+            moderation_results: [],
+            plugin_ids: null,
+            conversation_template_id: null,
+            gizmo_id: null,
+            is_archived: false,
+            safe_urls: [],
+          },
+        ],
+      };
+      const filePath = join(testDir, 'conversations.json');
+      writeFileSync(filePath, JSON.stringify(data));
+
+      const result = parser.parseConversations(filePath);
+      expect(result).toHaveLength(1);
+      expect(result[0].conversation_id).toBe('conv2');
+    });
+
+    it('throws error for invalid format', () => {
+      const filePath = join(testDir, 'conversations.json');
+      writeFileSync(filePath, JSON.stringify({ invalid: 'format' }));
+
+      expect(() => parser.parseConversations(filePath)).toThrow(
+        'Failed to parse conversations.json: Invalid conversations.json format'
+      );
+    });
+
+    it('throws error for invalid JSON', () => {
+      const filePath = join(testDir, 'conversations.json');
+      writeFileSync(filePath, 'not json content');
+
+      expect(() => parser.parseConversations(filePath)).toThrow('Failed to parse conversations.json');
+    });
+
+    it('throws error when file does not exist', () => {
+      expect(() => parser.parseConversations('/nonexistent/file.json')).toThrow();
+    });
+  });
+
+  describe('walkMessageTree', () => {
+    it('returns messages in BFS order', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: createMessage('msg1', 'user', 'Hello'),
+          parent: 'root',
+          children: ['msg2'],
+        },
+        msg2: {
+          id: 'msg2',
+          message: createMessage('msg2', 'assistant', 'Hi there'),
+          parent: 'msg1',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(2);
+      expect(result[0].author.role).toBe('user');
+      expect(result[1].author.role).toBe('assistant');
+    });
+
+    it('returns empty array when no root node found', () => {
+      const mapping: Record<string, MessageNode> = {
+        node1: {
+          id: 'node1',
+          message: createMessage('node1', 'user', 'Hello'),
+          parent: 'some-parent',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(0);
+    });
+
+    it('skips nodes without messages', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: createMessage('msg1', 'user', 'Hello'),
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(1);
+    });
+
+    it('skips system messages', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['sys', 'msg1'],
+        },
+        sys: {
+          id: 'sys',
+          message: createMessage('sys', 'system', 'System prompt'),
+          parent: 'root',
+          children: [],
+        },
+        msg1: {
+          id: 'msg1',
+          message: createMessage('msg1', 'user', 'Hello'),
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(1);
+      expect(result[0].author.role).toBe('user');
+    });
+
+    it('handles missing nodes in children gracefully', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1', 'nonexistent'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: createMessage('msg1', 'user', 'Hello'),
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(1);
+    });
+
+    it('handles messages with no content', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: {
+            id: 'msg1',
+            author: { role: 'user' },
+            create_time: 1700000000,
+            content: { content_type: 'text', parts: [] },
+            status: 'finished',
+            weight: 1,
+            metadata: {},
+            recipient: 'all',
+          },
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(0);
+    });
+
+    it('handles messages with null content', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: {
+            id: 'msg1',
+            author: { role: 'user' },
+            create_time: 1700000000,
+            content: null as any,
+            status: 'finished',
+            weight: 1,
+            metadata: {},
+            recipient: 'all',
+          },
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(0);
+    });
+
+    it('handles message with text content type', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: {
+            id: 'msg1',
+            author: { role: 'user' },
+            create_time: 1700000000,
+            content: { content_type: 'text', text: 'Hello text' },
+            status: 'finished',
+            weight: 1,
+            metadata: {},
+            recipient: 'all',
+          },
+          parent: 'root',
+          children: [],
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(1);
+    });
+
+    it('does not revisit visited nodes (handles cycles)', () => {
+      const mapping: Record<string, MessageNode> = {
+        root: {
+          id: 'root',
+          message: null,
+          parent: null,
+          children: ['msg1'],
+        },
+        msg1: {
+          id: 'msg1',
+          message: createMessage('msg1', 'user', 'Hello'),
+          parent: 'root',
+          children: ['root'], // circular reference
+        },
+      };
+
+      const result = parser.walkMessageTree(mapping);
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('extractTextContent', () => {
+    it('extracts text from text field', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = { content_type: 'text', text: 'Direct text' };
+
+      const result = parser.extractTextContent(message);
+      expect(result).toBe('Direct text');
+    });
+
+    it('extracts text from parts array', () => {
+      const message = createMessage('m1', 'user', 'Hello');
+
+      const result = parser.extractTextContent(message);
+      expect(result).toBe('Hello');
+    });
+
+    it('joins multiple string parts with newlines', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = { content_type: 'text', parts: ['Part 1', 'Part 2'] };
+
+      const result = parser.extractTextContent(message);
+      expect(result).toBe('Part 1\nPart 2');
+    });
+
+    it('filters out non-string parts (images)', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = {
+        content_type: 'multimodal_text',
+        parts: [
+          'Text part',
+          { asset_pointer: 'file://image.png', content_type: 'image/png' } as any,
+        ],
+      };
+
+      const result = parser.extractTextContent(message);
+      expect(result).toBe('Text part');
+    });
+
+    it('returns empty string when no content', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = { content_type: 'text' };
+
+      const result = parser.extractTextContent(message);
+      expect(result).toBe('');
+    });
+  });
+
+  describe('extractImages', () => {
+    it('extracts images from parts', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = {
+        content_type: 'multimodal_text',
+        parts: [
+          'Some text',
+          { asset_pointer: 'file://image1.png' } as any,
+          { asset_pointer: 'file://image2.jpg' } as any,
+        ],
+      };
+
+      const result = parser.extractImages(message);
+      expect(result).toEqual(['file://image1.png', 'file://image2.jpg']);
+    });
+
+    it('extracts images from attachments', () => {
+      const message = createMessage('m1', 'user', '');
+      message.metadata = {
+        attachments: [
+          { id: 'att1', name: 'photo.png', size: 100, mimeType: 'image/png' },
+          { id: 'att2', name: 'doc.pdf', size: 200, mimeType: 'application/pdf' },
+        ],
+      };
+
+      const result = parser.extractImages(message);
+      expect(result).toEqual(['att1']);
+    });
+
+    it('returns empty array when no images', () => {
+      const message = createMessage('m1', 'user', 'Text only');
+
+      const result = parser.extractImages(message);
+      expect(result).toEqual([]);
+    });
+
+    it('handles both parts images and attachment images', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = {
+        content_type: 'multimodal_text',
+        parts: [{ asset_pointer: 'file://part-image.png' } as any],
+      };
+      message.metadata = {
+        attachments: [{ id: 'att1', name: 'photo.png', size: 100, mimeType: 'image/jpeg' }],
+      };
+
+      const result = parser.extractImages(message);
+      expect(result).toEqual(['file://part-image.png', 'att1']);
+    });
+
+    it('handles missing parts', () => {
+      const message = createMessage('m1', 'user', '');
+      message.content = { content_type: 'text' };
+
+      const result = parser.extractImages(message);
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+function createMessage(
+  id: string,
+  role: 'user' | 'assistant' | 'system' | 'tool',
+  text: string
+): Message {
+  return {
+    id,
+    author: { role },
+    create_time: 1700000000,
+    content: {
+      content_type: 'text',
+      parts: text ? [text] : [],
+    },
+    status: 'finished_successfully',
+    weight: 1,
+    metadata: {},
+    recipient: 'all',
+  };
+}

--- a/tests/parsers/normalizer.test.ts
+++ b/tests/parsers/normalizer.test.ts
@@ -1,0 +1,271 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ConversationNormalizer } from '../../src/parsers/normalizer';
+import type { ChatGPTConversation, NormalizedConversation, MessageNode, Message } from '../../src/parsers/types';
+
+describe('ConversationNormalizer', () => {
+  let normalizer: ConversationNormalizer;
+
+  beforeEach(() => {
+    normalizer = new ConversationNormalizer();
+  });
+
+  describe('normalize', () => {
+    it('normalizes a ChatGPT conversation to common format', () => {
+      const conversation = createConversation('conv1', 'Test Chat', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', createMsg('msg1', 'user', 'Hello'), ['msg2']),
+        createMessageNode('msg2', 'msg1', createMsg('msg2', 'assistant', 'Hi there!'), []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+
+      expect(result.id).toBe('conv1');
+      expect(result.title).toBe('Test Chat');
+      expect(result.messages).toHaveLength(2);
+      expect(result.messages[0].role).toBe('user');
+      expect(result.messages[0].content).toBe('Hello');
+      expect(result.messages[1].role).toBe('assistant');
+      expect(result.messages[1].content).toBe('Hi there!');
+    });
+
+    it('uses "Untitled Conversation" when title is empty', () => {
+      const conversation = createConversation('conv1', '', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', createMsg('msg1', 'user', 'Hello'), []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.title).toBe('Untitled Conversation');
+    });
+
+    it('converts unix timestamps to Date objects', () => {
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, []),
+      ]);
+      conversation.create_time = 1700000000;
+      conversation.update_time = 1700001000;
+
+      const result = normalizer.normalize(conversation);
+      expect(result.created).toEqual(new Date(1700000000 * 1000));
+      expect(result.updated).toEqual(new Date(1700001000 * 1000));
+    });
+
+    it('normalizes tool role to assistant', () => {
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', createMsg('msg1', 'tool', 'Tool output'), []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].role).toBe('assistant');
+    });
+
+    it('normalizes unknown role to assistant (default case)', () => {
+      const msg = createMsg('msg1', 'user', 'Test');
+      (msg.author as any).role = 'custom_role';
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', msg, []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].role).toBe('assistant');
+    });
+
+    it('normalizes system role via private method', () => {
+      // normalizeRole is private, but we test it directly to cover the 'system' case
+      // which is unreachable via normalize() since walkMessageTree filters system messages
+      const normalizeRole = (normalizer as any).normalizeRole.bind(normalizer);
+      expect(normalizeRole('system')).toBe('system');
+      expect(normalizeRole('user')).toBe('user');
+      expect(normalizeRole('assistant')).toBe('assistant');
+      expect(normalizeRole('tool')).toBe('assistant');
+      expect(normalizeRole('unknown')).toBe('assistant');
+    });
+
+    it('preserves image references', () => {
+      const msg = createMsg('msg1', 'user', '');
+      msg.content = {
+        content_type: 'multimodal_text',
+        parts: [
+          'Check this',
+          { asset_pointer: 'file://image.png' } as any,
+        ],
+      };
+
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', msg, []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].images).toEqual(['file://image.png']);
+    });
+
+    it('preserves model metadata', () => {
+      const msg = createMsg('msg1', 'assistant', 'Response');
+      msg.metadata = { model_slug: 'gpt-4' };
+
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', msg, []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].metadata?.model).toBe('gpt-4');
+    });
+
+    it('preserves attachment metadata', () => {
+      const msg = createMsg('msg1', 'user', 'See attachment');
+      msg.metadata = {
+        attachments: [
+          { id: 'att1', name: 'doc.pdf', size: 1000, mimeType: 'application/pdf' },
+        ],
+      };
+
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', msg, []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].metadata?.attachments).toEqual(['doc.pdf']);
+    });
+
+    it('trims message content', () => {
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', createMsg('msg1', 'user', '  Hello  '), []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].content).toBe('Hello');
+    });
+
+    it('omits images array when no images present', () => {
+      const conversation = createConversation('conv1', 'Test', [
+        createMessageNode('root', null, null, ['msg1']),
+        createMessageNode('msg1', 'root', createMsg('msg1', 'user', 'Hello'), []),
+      ]);
+
+      const result = normalizer.normalize(conversation);
+      expect(result.messages[0].images).toBeUndefined();
+    });
+  });
+
+  describe('isValidConversation', () => {
+    it('returns true for conversation with content', () => {
+      const normalized: NormalizedConversation = {
+        id: 'conv1',
+        title: 'Test',
+        created: new Date(),
+        updated: new Date(),
+        messages: [
+          { role: 'user', content: 'Hello', timestamp: new Date() },
+        ],
+      };
+
+      expect(normalizer.isValidConversation(normalized)).toBe(true);
+    });
+
+    it('returns false for conversation with no messages', () => {
+      const normalized: NormalizedConversation = {
+        id: 'conv1',
+        title: 'Test',
+        created: new Date(),
+        updated: new Date(),
+        messages: [],
+      };
+
+      expect(normalizer.isValidConversation(normalized)).toBe(false);
+    });
+
+    it('returns false when all messages have empty content', () => {
+      const normalized: NormalizedConversation = {
+        id: 'conv1',
+        title: 'Test',
+        created: new Date(),
+        updated: new Date(),
+        messages: [
+          { role: 'user', content: '', timestamp: new Date() },
+          { role: 'assistant', content: '', timestamp: new Date() },
+        ],
+      };
+
+      expect(normalizer.isValidConversation(normalized)).toBe(false);
+    });
+
+    it('returns true when at least one message has content', () => {
+      const normalized: NormalizedConversation = {
+        id: 'conv1',
+        title: 'Test',
+        created: new Date(),
+        updated: new Date(),
+        messages: [
+          { role: 'user', content: '', timestamp: new Date() },
+          { role: 'assistant', content: 'Response', timestamp: new Date() },
+        ],
+      };
+
+      expect(normalizer.isValidConversation(normalized)).toBe(true);
+    });
+  });
+});
+
+function createConversation(
+  id: string,
+  title: string,
+  nodes: { id: string; node: MessageNode }[]
+): ChatGPTConversation {
+  const mapping: Record<string, MessageNode> = {};
+  for (const { id, node } of nodes) {
+    mapping[id] = node;
+  }
+
+  return {
+    conversation_id: id,
+    title,
+    create_time: 1700000000,
+    update_time: 1700001000,
+    mapping,
+    current_node: nodes.length > 0 ? nodes[nodes.length - 1].id : '',
+    moderation_results: [],
+    plugin_ids: null,
+    conversation_template_id: null,
+    gizmo_id: null,
+    is_archived: false,
+    safe_urls: [],
+  };
+}
+
+function createMessageNode(
+  id: string,
+  parent: string | null,
+  message: Message | null,
+  children: string[]
+): { id: string; node: MessageNode } {
+  return {
+    id,
+    node: { id, message, parent, children },
+  };
+}
+
+function createMsg(
+  id: string,
+  role: 'user' | 'assistant' | 'system' | 'tool',
+  text: string
+): Message {
+  return {
+    id,
+    author: { role },
+    create_time: 1700000000,
+    content: {
+      content_type: 'text',
+      parts: [text],
+    },
+    status: 'finished_successfully',
+    weight: 1,
+    metadata: {},
+    recipient: 'all',
+  };
+}

--- a/tests/utils/file.test.ts
+++ b/tests/utils/file.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, existsSync, rmSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ensureDir, writeFile, copyImages, sanitizeFilename, formatFileSize } from '../../src/utils/file';
+
+describe('ensureDir', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `file-test-${Date.now()}`);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('creates directory when it does not exist', () => {
+    const dirPath = join(testDir, 'new-dir');
+    expect(existsSync(dirPath)).toBe(false);
+    ensureDir(dirPath);
+    expect(existsSync(dirPath)).toBe(true);
+  });
+
+  it('does nothing when directory already exists', () => {
+    mkdirSync(testDir, { recursive: true });
+    expect(existsSync(testDir)).toBe(true);
+    ensureDir(testDir);
+    expect(existsSync(testDir)).toBe(true);
+  });
+
+  it('creates nested directories recursively', () => {
+    const nestedPath = join(testDir, 'a', 'b', 'c');
+    ensureDir(nestedPath);
+    expect(existsSync(nestedPath)).toBe(true);
+  });
+});
+
+describe('writeFile', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = join(tmpdir(), `writefile-test-${Date.now()}`);
+  });
+
+  afterEach(() => {
+    if (existsSync(testDir)) {
+      rmSync(testDir, { recursive: true, force: true });
+    }
+  });
+
+  it('writes content to a file', () => {
+    const filePath = join(testDir, 'test.txt');
+    writeFile(filePath, 'hello world');
+    expect(readFileSync(filePath, 'utf-8')).toBe('hello world');
+  });
+
+  it('creates parent directories if they do not exist', () => {
+    const filePath = join(testDir, 'sub', 'dir', 'test.txt');
+    writeFile(filePath, 'nested content');
+    expect(readFileSync(filePath, 'utf-8')).toBe('nested content');
+  });
+
+  it('overwrites existing file', () => {
+    const filePath = join(testDir, 'overwrite.txt');
+    writeFile(filePath, 'original');
+    writeFile(filePath, 'updated');
+    expect(readFileSync(filePath, 'utf-8')).toBe('updated');
+  });
+});
+
+describe('copyImages', () => {
+  let sourceDir: string;
+  let destDir: string;
+
+  beforeEach(() => {
+    const base = join(tmpdir(), `copyimg-test-${Date.now()}`);
+    sourceDir = join(base, 'source');
+    destDir = join(base, 'dest');
+    mkdirSync(sourceDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    const base = sourceDir.substring(0, sourceDir.lastIndexOf('/'));
+    if (existsSync(base)) {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it('returns 0 when source directory does not exist', () => {
+    const result = copyImages('/nonexistent-dir-xyz', destDir);
+    expect(result).toBe(0);
+  });
+
+  it('copies files from source to destination', () => {
+    writeFileSync(join(sourceDir, 'img1.png'), 'image1');
+    writeFileSync(join(sourceDir, 'img2.jpg'), 'image2');
+    const count = copyImages(sourceDir, destDir);
+    expect(count).toBe(2);
+    expect(existsSync(join(destDir, 'img1.png'))).toBe(true);
+    expect(existsSync(join(destDir, 'img2.jpg'))).toBe(true);
+  });
+
+  it('skips directories in source', () => {
+    writeFileSync(join(sourceDir, 'img.png'), 'image');
+    mkdirSync(join(sourceDir, 'subdir'));
+    const count = copyImages(sourceDir, destDir);
+    expect(count).toBe(1);
+  });
+
+  it('creates destination directory if needed', () => {
+    writeFileSync(join(sourceDir, 'img.png'), 'image');
+    expect(existsSync(destDir)).toBe(false);
+    copyImages(sourceDir, destDir);
+    expect(existsSync(destDir)).toBe(true);
+  });
+});
+
+describe('sanitizeFilename', () => {
+  it('converts to lowercase and replaces special chars with hyphens', () => {
+    expect(sanitizeFilename('Hello World!')).toBe('hello-world');
+  });
+
+  it('removes leading and trailing hyphens', () => {
+    expect(sanitizeFilename('---Hello---')).toBe('hello');
+  });
+
+  it('truncates to max length', () => {
+    const longName = 'a'.repeat(100);
+    expect(sanitizeFilename(longName).length).toBeLessThanOrEqual(50);
+  });
+
+  it('respects custom max length', () => {
+    const longName = 'a'.repeat(100);
+    expect(sanitizeFilename(longName, 20).length).toBeLessThanOrEqual(20);
+  });
+
+  it('handles empty string', () => {
+    expect(sanitizeFilename('')).toBe('');
+  });
+
+  it('handles string with only special characters', () => {
+    expect(sanitizeFilename('!@#$%')).toBe('');
+  });
+
+  it('preserves alphanumeric characters', () => {
+    expect(sanitizeFilename('abc123')).toBe('abc123');
+  });
+});
+
+describe('formatFileSize', () => {
+  it('formats bytes', () => {
+    expect(formatFileSize(500)).toBe('500 B');
+  });
+
+  it('formats zero bytes', () => {
+    expect(formatFileSize(0)).toBe('0 B');
+  });
+
+  it('formats kilobytes', () => {
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+    expect(formatFileSize(1536)).toBe('1.5 KB');
+  });
+
+  it('formats megabytes', () => {
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+    expect(formatFileSize(2.5 * 1024 * 1024)).toBe('2.5 MB');
+  });
+
+  it('formats gigabytes', () => {
+    expect(formatFileSize(1024 * 1024 * 1024)).toBe('1.0 GB');
+    expect(formatFileSize(3.7 * 1024 * 1024 * 1024)).toBe('3.7 GB');
+  });
+
+  it('uses correct boundary values', () => {
+    expect(formatFileSize(1023)).toBe('1023 B');
+    expect(formatFileSize(1024)).toBe('1.0 KB');
+    expect(formatFileSize(1024 * 1024 - 1)).toContain('KB');
+    expect(formatFileSize(1024 * 1024)).toBe('1.0 MB');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json-summary', 'json'],
+      include: ['src/**/*.ts'],
+      exclude: ['src/index.ts', 'src/parsers/types.ts'],
+    },
+  },
+});


### PR DESCRIPTION
Add Vitest test framework with v8 coverage reporting. Create 115 tests
across 6 test files covering all source modules: ChatGPT parser,
conversation normalizer, markdown formatter, ZIP extractor, Ollama
analyzer, and file utilities. Add coverage badge to README.

https://claude.ai/code/session_01XZQGjwyQfyUcUqdwSmSHmn