### PR TITLE
feat: add Docker and Docker Compose for MCP server and web UI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+node_modules/
+dist/
+ui/node_modules/
+ui/dist/
+coverage/
+test-output/
+claude-export/
+output/
+temp/
+*.zip
+*.log
+*.png
+!docs/*.png
+.DS_Store
+.env
+.git/
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Stage 1: Build
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+# Install CLI/MCP dependencies
+COPY package.json package-lock.json* ./
+RUN npm install
+
+# Copy source and build TypeScript
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+# Stage 2: Production
+FROM node:20-slim
+
+WORKDIR /app
+
+# Install production dependencies only
+COPY package.json package-lock.json* ./
+RUN npm install --omit=dev
+
+# Copy built output from builder
+COPY --from=builder /app/dist ./dist
+
+# Create the default context store directory
+RUN mkdir -p /root/.opencontext
+
+# Persistent volume for context data
+VOLUME /root/.opencontext
+
+# Allow overriding the store path via environment variable
+ENV OPENCONTEXT_STORE_PATH=/root/.opencontext/contexts.json
+
+# The MCP server uses stdio transport, so the container entrypoint
+# is the MCP server process. Run with `docker run -i` to enable
+# stdin/stdout communication.
+ENTRYPOINT ["node", "dist/mcp/index.js"]

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,0 +1,23 @@
+# Stage 1: Build the UI
+FROM node:20-slim AS builder
+
+WORKDIR /app
+
+COPY ui/package.json ui/package-lock.json* ./
+RUN npm install
+
+COPY ui/ ./
+RUN npm run build
+
+# Stage 2: Serve with a lightweight static server
+FROM node:20-slim
+
+WORKDIR /app
+
+RUN npm install -g serve@14
+
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 5173
+
+CMD ["serve", "-s", "dist", "-l", "5173"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,47 @@
+services:
+  # MCP Server — communicates via stdio transport.
+  #
+  # Build:
+  #   docker compose build mcp
+  #
+  # Use with Claude Code (~/.claude/settings.json):
+  #   {
+  #     "mcpServers": {
+  #       "opencontext": {
+  #         "command": "docker",
+  #         "args": ["run", "-i", "--rm", "-v", "opencontext-data:/root/.opencontext", "opencontext-mcp"]
+  #       }
+  #     }
+  #   }
+  #
+  # Or run directly:
+  #   docker compose run --rm mcp
+  mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: opencontext-mcp
+    container_name: opencontext-mcp
+    stdin_open: true
+    volumes:
+      - opencontext-data:/root/.opencontext
+    environment:
+      - OPENCONTEXT_STORE_PATH=/root/.opencontext/contexts.json
+
+  # Web UI — React dashboard for managing preferences, conversations, and exports.
+  #
+  # Start:
+  #   docker compose up ui
+  #
+  # Then open http://localhost:5173
+  ui:
+    build:
+      context: .
+      dockerfile: Dockerfile.ui
+    image: opencontext-ui
+    container_name: opencontext-ui
+    ports:
+      - "5173:5173"
+
+volumes:
+  opencontext-data:


### PR DESCRIPTION
Add containerized deployment support so users can run the opencontext
MCP server and web UI with Docker without needing a local Node.js setup.

- Dockerfile: multi-stage build for the MCP server (stdio transport)
- Dockerfile.ui: multi-stage build for the React web UI served via `serve`
- docker-compose.yml: defines `mcp` and `ui` services with a named volume
  for persistent context storage
- .dockerignore: excludes node_modules, dist, and other build artifacts

Usage:
  docker compose build mcp
  # Then configure Claude Code to use:
  #   docker run -i --rm -v opencontext-data:/root/.opencontext opencontext-mcp

https://claude.ai/code/session_017xKn1nkcbZARcoFAHpPtJa