### PR TITLE
fix(ui): unblock Cloudflare Pages build (eslint 10 peer conflict)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,7 +30,7 @@
         "@vitejs/plugin-react": "^5.2.0",
         "@vitest/coverage-v8": "^4.1.8",
         "eslint": "^10.8.1",
-        "eslint-plugin-react-hooks": "^7.0.1",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
         "jsdom": "^26.1.0",
@@ -5371,9 +5371,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5387,7 +5387,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -38,7 +38,7 @@
     "@vitejs/plugin-react": "^5.2.0",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^10.8.1",
-    "eslint-plugin-react-hooks": "^7.0.1",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
     "jsdom": "^26.1.0",


### PR DESCRIPTION
## Problem

The Cloudflare Pages build is failing on `main`. It never reaches the build step — it dies during dependency install.

Reproduced locally against `origin/main` (018a6fc):

```
$ cd ui && npm ci
npm error code ERESOLVE
npm error While resolving: eslint-plugin-react-hooks@7.0.1
npm error Found: eslint@10.8.1
npm error Could not resolve dependency:
npm error peer eslint@"^3.0.0 || ... || ^9.0.0" from eslint-plugin-react-hooks@7.0.1
```

## Root cause

A Dependabot bump moved `ui/` to `eslint@^10.8.1`, but left `eslint-plugin-react-hooks` at `^7.0.1`, whose peer range stops at eslint 9:

```
7.0.1 → ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
7.1.1 → ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
```

`npm ci` refuses the install, so Pages fails before `vite build` runs.

## Fix

Bump `eslint-plugin-react-hooks` to `^7.1.1`. That is the whole change.

I checked the rest of the eslint stack rather than bumping blindly — nothing else needed changing:

| Package | eslint peer range | eslint 10 OK? |
|---|---|---|
| `typescript-eslint@8.67.0` | `^8.57.0 \|\| ^9.0.0 \|\| ^10.0.0` | ✅ already |
| `eslint-plugin-react-refresh@0.4.24` | `>=8.40` | ✅ already |
| `eslint-plugin-react-hooks@7.0.1` | `… \|\| ^9.0.0` | ❌ **the blocker** |

## Verification

Run against `origin/main` with this patch applied:

- ✅ `cd ui && npm ci` — succeeds (was the failing step)
- ✅ `cd ui && npm run build` — `tsc -b && vite build`, built in 357ms
- ✅ `npm ci` at repo root — succeeds
- ✅ `npm run build` at repo root — succeeds

## Note on lint (not addressed here, and not blocking)

`npm run lint` reports errors, but this is **pre-existing and unrelated to the deploy**:

- Baseline on `origin/main` (forced install via `--legacy-peer-deps`): **27 errors**
- With this patch: **32 errors**

The 5 additional errors come from new rules shipped in react-hooks 7.1.x (`react-hooks/immutability`, `react-hooks/error-boundaries`), not from anything this PR changes in application code.

Lint is **not** part of the Pages build (`npm run build` is `tsc -b && vite build`) and there is no lint CI workflow, so none of this blocks the deploy. Worth a separate cleanup PR — deliberately left out of this one to keep the deploy fix minimal and easy to review.
